### PR TITLE
Resolve nested JSKOS contexts offline #53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ stage/
 *.tmp
 tmp/
 .vscode/settings.json
+.idea/

--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ Received data in RDF or JSKOS format must be syntactically valid. Additional con
 
 **JSKOS data** (for terminologies and mappings) is not validated yet (see [open issue](https://github.com/nfdi4objects/n4o-graph-importer/issues/50)).
 
+JSON-LD context declarations are preserved but never retrieved from the
+network. The canonical JSKOS context at
+<https://gbv.github.io/jskos/context.json> is read from the bundled copy; any
+other remote context URL is rejected.
+
 **RDF data** is allowed to contain any absolute IRI references matching the regular expression `` ^[a-z][a-z0-9+.-]*:[^<>"{}|^`\\\x00-\x20]*$ ``. This includes some IRI references invalid in theory but  supported by most RDF software in practice. Additional constraints on RDF data do not result in validation errors but malformed triples are filtered out (as described in the following) and collected as part of [report] files.
 
 ### Filtering

--- a/lib/rdf.py
+++ b/lib/rdf.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from pyld import jsonld
 from .errors import ValidationError
 from .walk import walk
@@ -6,7 +5,7 @@ from .validate import invalidIRI
 from pyoxigraph import parse, RdfFormat
 
 
-def _offline_document_loader(documents):
+def context_loader(documents):
     """Load allowlisted JSON-LD contexts from local documents only."""
     def load(url, options=None):
         if url not in documents:
@@ -14,7 +13,7 @@ def _offline_document_loader(documents):
         return {
             "contentType": "application/ld+json",
             "contextUrl": None,
-            "document": deepcopy(documents[url]),
+            "document": documents[url],
             "documentUrl": url,
         }
     return load
@@ -22,7 +21,6 @@ def _offline_document_loader(documents):
 
 def jsonld2nt(doc, context, remote_contexts=None):
     """Convert JSON-LD to N-Quads without fetching remote contexts."""
-    doc = deepcopy(doc)
     remote_contexts = remote_contexts or {}
     if type(doc) is list:
         doc = {"@context": context, "@graph": doc}
@@ -30,7 +28,7 @@ def jsonld2nt(doc, context, remote_contexts=None):
         doc["@context"] = context
     try:
         expanded = jsonld.expand(doc, options={
-            "documentLoader": _offline_document_loader(remote_contexts)
+            "documentLoader": context_loader(remote_contexts)
         })
     except jsonld.JsonLdError as error:
         # PyLD wraps exceptions raised by document loaders.

--- a/lib/rdf.py
+++ b/lib/rdf.py
@@ -22,12 +22,9 @@ def context_loader(documents):
 def jsonld2nt(doc, context, remote_contexts=None):
     """Convert JSON-LD to N-Quads without fetching remote contexts."""
     remote_contexts = remote_contexts or {}
-    if type(doc) is list:
-        doc = {"@context": context, "@graph": doc}
-    elif "@context" not in doc:
-        doc["@context"] = context
     try:
         expanded = jsonld.expand(doc, options={
+            "expandContext": context,
             "documentLoader": context_loader(remote_contexts)
         })
     except jsonld.JsonLdError as error:

--- a/lib/rdf.py
+++ b/lib/rdf.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pyld import jsonld
 from .errors import ValidationError
 from .walk import walk
@@ -5,14 +6,39 @@ from .validate import invalidIRI
 from pyoxigraph import parse, RdfFormat
 
 
-def jsonld2nt(doc, context):
+def _offline_document_loader(documents):
+    """Load allowlisted JSON-LD contexts from local documents only."""
+    def load(url, options=None):
+        if url not in documents:
+            raise ValidationError(f"Unsupported remote JSON-LD context: {url}")
+        return {
+            "contentType": "application/ld+json",
+            "contextUrl": None,
+            "document": deepcopy(documents[url]),
+            "documentUrl": url,
+        }
+    return load
+
+
+def jsonld2nt(doc, context, remote_contexts=None):
+    """Convert JSON-LD to N-Quads without fetching remote contexts."""
+    doc = deepcopy(doc)
+    remote_contexts = remote_contexts or {}
     if type(doc) is list:
-        for e in doc:
-            e.pop("@context", None)
         doc = {"@context": context, "@graph": doc}
-    else:
+    elif "@context" not in doc:
         doc["@context"] = context
-    expanded = jsonld.expand(doc)
+    try:
+        expanded = jsonld.expand(doc, options={
+            "documentLoader": _offline_document_loader(remote_contexts)
+        })
+    except jsonld.JsonLdError as error:
+        # PyLD wraps exceptions raised by document loaders.
+        url = error.details.get("url")
+        if error.code == "loading remote context failed" and url not in remote_contexts:
+            raise ValidationError(
+                f"Unsupported remote JSON-LD context: {url}")
+        raise
     return jsonld.to_rdf(expanded, options={'format': 'application/n-quads'})
 
 

--- a/lib/registry.py
+++ b/lib/registry.py
@@ -13,6 +13,7 @@ import re
 
 class Registry:
     context = None
+    remote_contexts = {}
     schema = None
     auto_ids = True
 
@@ -92,7 +93,7 @@ class Registry:
     def update_metadata(self):
         query = f"SELECT * {{ GRAPH <{self.graph}> {{ VALUES (?p) {{(dct:issued)}} ?s ?p ?o }} }}"
         issued = self.sparql.query(query, "nq")
-        metadata = jsonld2nt(self.list(), self.context)
+        metadata = jsonld2nt(self.list(), self.context, self.remote_contexts)
         file = self.stage / f"{self.kind}.ttl"
         with open(file, "w") as f:
             f.write(metadata)

--- a/lib/terminologies.py
+++ b/lib/terminologies.py
@@ -6,9 +6,12 @@ from .errors import NotFound
 from .rdf import jsonld2nt
 from .registry import Registry
 
+JSKOS_CONTEXT_URL = "https://gbv.github.io/jskos/context.json"
+
 
 class TerminologyRegistry(Registry):
     context = read_json(Path(__file__).parent / 'jskos-context.json')
+    remote_contexts = {JSKOS_CONTEXT_URL: context}
     skosmos_context = read_json(Path(__file__).parent / 'skosmos-context.json')
     auto_ids = False
 
@@ -31,8 +34,9 @@ class TerminologyRegistry(Registry):
 
         return ttl
 
-    def register(self, item):
-        id = str(int(item.get("id")))
+    def _resolve(self, item):
+        item = self.validate(item)
+        id = str(int(item["id"]))
         uri = f"{self.prefix}{id}"
 
         bartoc = Path(self.data) / 'bartoc.json'
@@ -44,7 +48,24 @@ class TerminologyRegistry(Registry):
         if not len(voc):
             raise NotFound(f"Terminology not found: {uri}")
 
-        return super().register(voc[0], id)
+        data = self.validate(voc[0], id)
+        jsonld2nt(data, self.context, self.remote_contexts)
+        return data
+
+    def register(self, item):
+        data = self._resolve(item)
+        return super().register(data, data["id"])
+
+    def replace(self, items):
+        if type(items) is not list:
+            return super().replace(items)
+
+        records = [self._resolve(item) for item in items]
+
+        self.purge()
+        for record in records:
+            Registry.register(self, record, record["id"])
+        return self.list()
 
     def update_distribution(self, id, log, published=True):
         super().update_distribution(id, log, published)
@@ -64,8 +85,10 @@ class TerminologyRegistry(Registry):
 
         voc["a"] = ["skosmos:Vocabulary", "void:Dataset"]
         voc["id"] = f"{self.graph}{id}/stage/skosmos.ttl#{id}"
+        if "@context" in voc:
+            voc["@context"] = [voc["@context"], self.skosmos_context]
         with open(skosmos, "w") as f:
-            ttl = jsonld2nt(voc, self.skosmos_context)
+            ttl = jsonld2nt(voc, self.skosmos_context, self.remote_contexts)
             ttl = "\n".join(sorted(ttl.rstrip().split("\n")))
             f.write(ttl)
 
@@ -74,7 +97,7 @@ class TerminologyRegistry(Registry):
             log.append("Converting JSKOS to RDF")
             with open(original) as file:
                 jskos = [json.loads(line) for line in file]
-            rdf = jsonld2nt(jskos, self.context)
+            rdf = jsonld2nt(jskos, self.context, self.remote_contexts)
             original = self.stage / str(id) / "original.ttl"
             with open(original, "w") as f:
                 f.write(rdf)

--- a/tests/test_terminologies.py
+++ b/tests/test_terminologies.py
@@ -1,0 +1,76 @@
+import pytest
+
+from lib import (
+    TerminologyRegistry,
+    ValidationError,
+    createTripleStore,
+    write_json,
+)
+
+
+JSKOS_CONTEXT_URL = "https://gbv.github.io/jskos/context.json"
+
+
+def terminology(terminology_id, nested_context=JSKOS_CONTEXT_URL):
+    """Create a minimal terminology with a nested JSON-LD context."""
+    return {
+        "@context": JSKOS_CONTEXT_URL,
+        "uri": f"http://bartoc.org/en/node/{terminology_id}",
+        "subject": [{
+            "@context": nested_context,
+            "uri": "http://dewey.info/class/3/e23/",
+            "notation": ["3"],
+        }],
+    }
+
+
+def test_nested_contexts(tmp_path, monkeypatch):
+    # The conversion must not make HTTP requests.
+    def fail_network(*_args, **_kwargs):
+        raise AssertionError(
+            "JSON-LD context unexpectedly fetched over the network")
+
+    monkeypatch.setattr("requests.get", fail_network)
+
+    data = tmp_path / "data"
+    data.mkdir()
+    dump = data / "bartoc.json"
+    write_json(dump, [terminology(1578)])
+
+    store = createTripleStore()
+    registry = TerminologyRegistry(
+        base="http://example.org/",
+        data=data,
+        stage=tmp_path / "stage",
+        store=store,
+    )
+
+    # A different fallback proves that the declared context is preserved.
+    registry.context = {
+        "uri": "@id",
+        "subject": "http://example.org/fallback-subject",
+    }
+
+    # The known JSKOS context is loaded from the bundled local copy.
+    registry.replace([{"uri": "http://bartoc.org/en/node/1578"}])
+    assert [item["id"] for item in registry.list()] == ["1578"]
+
+    # The metadata graph proves that "subject" was mapped by the JSKOS context.
+    graph = "http://example.org/terminology/"
+    query = (
+        f"SELECT * {{ GRAPH <{graph}> "
+        "{ ?s <http://purl.org/dc/terms/subject> ?o } }"
+    )
+    assert len(store.query(query)) == 1
+
+    # Remember the graph size before attempting an invalid replacement.
+    query = f"SELECT * {{ GRAPH <{graph}> {{ ?s ?p ?o }} }}"
+    triple_count = len(store.query(query))
+
+    write_json(dump, [terminology(1579, "https://example.org/context.json")])
+    with pytest.raises(ValidationError, match="Unsupported remote"):
+        registry.replace([{"uri": "http://bartoc.org/en/node/1579"}])
+
+    # An unknown context must leave the registry and graph unchanged.
+    assert [item["id"] for item in registry.list()] == ["1578"]
+    assert len(store.query(query)) == triple_count


### PR DESCRIPTION
Closes #53.

Adds an offline PyLD document loader that resolves the canonical JSKOS context from the bundled file. Unknown remote contexts are rejected before registry or graph data is modified.

### Testing

- Added regression coverage for supported and unsupported nested contexts.
- Tested locally four live BARTOC records, including `1578`.
- With network access blocked, `PUT /terminology/` returned HTTP 200 and both nested DDC subjects were correctly converted to RDF.